### PR TITLE
Community recipes, setup imports for all devices, and UI link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ app/sessions/*/*/*
 app/recipes/*.zip
 app/sessions/*.zip
 
+# allow committed snapshots of recipes
+!recipes_snapshot/
+
 scripts/docker/nginx/certs/*
 
 # terraform

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ Allows for full control of the PicoBrew Pico S/C/Pro & Zymatic models.  Shout ou
 ## Installation
 ![GitHub tag (latest SemVer pre-release)](https://img.shields.io/github/v/tag/chiefwigms/picobrew_pico?include_prereleases&sort=semver)
 
+### Quick Start (Local)
+On macOS/Linux:
+
+```
+chmod +x setup.sh
+./setup.sh
+```
+
+On Windows:
+
+```
+setup.bat
+```
+
+The setup script will:
+- Create and use a Python virtual environment (.venv)
+- Install all required dependencies
+- Prepare config and required directories
+- Start the server in the background and verify health
+- Run a smoke test against key endpoints
+- Open your default web browser to the running server
+
+See SETUP_README.md for more details and options.
+
+### Raspberry Pi Image
 Refer to the [Releases Page](https://github.com/chiefwigms/picobrew_pico/releases) for steps to get up and running with your own Pico server with a Raspberry Pi device (recommended models include: Raspberry Pi Zero-W or Raspberry Pi 4).
 
 By default the hostname of the RaspberryPi device will be "raspberrypi" and is discoverable on your local network along with the "samba" (or network shares) for sessions and recipes. You can use these to view the files created by the server during interactions with the user and connected devices.

--- a/SETUP_README.md
+++ b/SETUP_README.md
@@ -21,11 +21,14 @@ setup.bat
 
 That's it! The script will:
 1. ✅ Check if Python is installed
-2. ✅ Install all required dependencies
-3. ✅ Create necessary directories
-4. ✅ Set up configuration files
-5. ✅ Find an available port automatically
-6. ✅ Start the server
+2. ✅ Create and activate a virtual environment (.venv)
+3. ✅ Install all required dependencies (and pytest)
+4. ✅ Create necessary directories
+5. ✅ Set up configuration files
+6. ✅ Find an available port automatically
+7. ✅ Start the server in the background and verify /health
+8. ✅ Run a smoke test (scripts/smoke.sh) against key endpoints
+9. ✅ Open your default web browser to the server
 
 ## What the Setup Scripts Do
 
@@ -44,7 +47,8 @@ That's it! The script will:
 - **Root Handling**: Uses port 80 if available, falls back to 8080+ if not
 - **Conflict Resolution**: Avoids port conflicts automatically
 
-## Command Line Options
+### Command Line Options
+Note: The setup script automatically opens your default browser to the running server.
 
 ### Basic Usage
 ```bash
@@ -93,6 +97,13 @@ chmod +x setup.sh
 **"pip not found":**
 - The script checks for both `pip` and `pip3`
 - Install pip: `python3 -m ensurepip --upgrade`
+
+### Smoke Test Script
+You can run the smoke test manually at any time:
+
+```bash
+bash scripts/smoke.sh http://localhost:8080 12345678901234567890123456789012
+```
 
 ### Manual Setup (if scripts fail)
 

--- a/SETUP_README.md
+++ b/SETUP_README.md
@@ -98,6 +98,15 @@ chmod +x setup.sh
 - The script checks for both `pip` and `pip3`
 - Install pip: `python3 -m ensurepip --upgrade`
 
+## Importing Snapshot Recipes
+
+If this repository includes a recipes_snapshot directory, you can import them after install:
+
+```bash
+# Z-series snapshot import
+cp -R recipes_snapshot/zseries/* app/recipes/zseries/
+```
+
 ### Smoke Test Script
 You can run the smoke test manually at any time:
 

--- a/app/templates/community_recipes.html
+++ b/app/templates/community_recipes.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container">
+  <h2>Community / Snapshot Recipes</h2>
+  <p>This page lists recipe snapshots bundled with this server. You can import them during setup or manually copy them into the library.</p>
+
+  {% if snapshot.zseries and snapshot.zseries|length > 0 %}
+  <h3>Z-series ({{ snapshot.zseries|length }})</h3>
+  <ul>
+    {% for r in snapshot.zseries %}
+      <li>{{ r.name }} <small>({{ r.filename }})</small></li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  <p>No Z-series snapshot recipes bundled.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -26,6 +26,8 @@
         <a class="dropdown-item nav-link bg-dark" href="/zseries_recipes">Library</a>
         <a class="dropdown-item nav-link bg-dark" href="/new_zseries_recipe">New</a>
         <a class="dropdown-item nav-link bg-dark" href="/import_zseries_recipe">Import</a>
+        <div role="separator" class="dropdown-divider bg-dark"></div>
+        <a class="dropdown-item nav-link bg-dark" href="/community_recipes">Community/Snapshots</a>
       </div>
     </li>
     <li class="nav-item dropdown">

--- a/recipes_snapshot/zseries/American_Lager_____-.json
+++ b/recipes_snapshot/zseries/American_Lager_____-.json
@@ -1,0 +1,50 @@
+{
+    "clean": false,
+    "id": 153831,
+    "name": "American Lager     -",
+    "start_water": 12.72,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 60,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 53
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 53
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/American_Pale_Ale__-.json
+++ b/recipes_snapshot/zseries/American_Pale_Ale__-.json
@@ -1,0 +1,57 @@
+{
+    "clean": false,
+    "id": 153832,
+    "name": "American Pale Ale  -",
+    "start_water": 13.25,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 55,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct2",
+            "name": "Boil Adjunct 2",
+            "step_time": 5,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 71
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 71
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/American_Porter____-.json
+++ b/recipes_snapshot/zseries/American_Porter____-.json
@@ -1,0 +1,57 @@
+{
+    "clean": false,
+    "id": 153830,
+    "name": "American Porter    -",
+    "start_water": 13.59,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 30,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct2",
+            "name": "Boil Adjunct 2",
+            "step_time": 30,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 66
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 66
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Chicken.json
+++ b/recipes_snapshot/zseries/Chicken.json
@@ -1,0 +1,22 @@
+{
+    "clean": false,
+    "id": 153839,
+    "name": "Chicken",
+    "start_water": 1.21,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat Water",
+            "step_time": 0,
+            "temperature": 145
+        },
+        {
+            "drain_time": 5,
+            "location": "Mash",
+            "name": "Cook",
+            "step_time": 120,
+            "temperature": 145
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/H2_Berliner_Weisse.json
+++ b/recipes_snapshot/zseries/H2_Berliner_Weisse.json
@@ -1,0 +1,85 @@
+{
+    "clean": false,
+    "id": 160619,
+    "name": "H2 Berliner Weisse",
+    "start_water": 12.15,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 149
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 149
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Mash Out",
+            "step_time": 0,
+            "temperature": 167
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Mash Out",
+            "step_time": 10,
+            "temperature": 167
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Pre-hop Boil",
+            "step_time": 45,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 15,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Cool to Whirlpoo...",
+            "step_time": 0,
+            "temperature": 175
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct2",
+            "name": "Whirlpool Step",
+            "step_time": 10,
+            "temperature": 175
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 61
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 61
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Hazy_IPA___________-.json
+++ b/recipes_snapshot/zseries/Hazy_IPA___________-.json
@@ -1,0 +1,64 @@
+{
+    "clean": false,
+    "id": 153829,
+    "name": "Hazy IPA           -",
+    "start_water": 13.89,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 5,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct2",
+            "name": "Boil Adjunct 2",
+            "step_time": 1,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct3",
+            "name": "Boil Adjunct 3",
+            "step_time": 9,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 65
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 65
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Medusa_Smash_V1..json
+++ b/recipes_snapshot/zseries/Medusa_Smash_V1..json
@@ -1,0 +1,134 @@
+{
+    "clean": false,
+    "id": 147720,
+    "name": "Medusa Smash V1.",
+    "start_water": 12.45,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Temp",
+            "step_time": 0,
+            "temperature": 104
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Dough In",
+            "step_time": 20,
+            "temperature": 104
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Heat to  Mash 1",
+            "step_time": 0,
+            "temperature": 145
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Mash 1",
+            "step_time": 40,
+            "temperature": 145
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Heat to  Mash 2",
+            "step_time": 0,
+            "temperature": 161
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Mash 2",
+            "step_time": 80,
+            "temperature": 161
+        },
+        {
+            "drain_time": 4,
+            "location": "Mash",
+            "name": "Heat to  Mash Out",
+            "step_time": 0,
+            "temperature": 175
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Mash Out",
+            "step_time": 20,
+            "temperature": 175
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Pre-hop Boil",
+            "step_time": 30,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 30,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct2",
+            "name": "Boil Adjunct 2",
+            "step_time": 20,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct3",
+            "name": "Boil Adjunct 3",
+            "step_time": 10,
+            "temperature": 207
+        },
+        {
+            "drain_time": 8,
+            "location": "PassThru",
+            "name": "Balance Temps",
+            "step_time": 1,
+            "temperature": 0
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Cool to Whirlpoo...",
+            "step_time": 0,
+            "temperature": 175
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct4",
+            "name": "Whirlpool Step",
+            "step_time": 15,
+            "temperature": 175
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 70
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 70
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Rye-Licious_Rye.json
+++ b/recipes_snapshot/zseries/Rye-Licious_Rye.json
@@ -1,0 +1,99 @@
+{
+    "clean": false,
+    "id": 153800,
+    "name": "Rye-Licious Rye",
+    "start_water": 13.1,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Dough In",
+            "step_time": 0,
+            "temperature": 113
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Dough In",
+            "step_time": 20,
+            "temperature": 113
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Mash 1",
+            "step_time": 20,
+            "temperature": 113
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Mash 2",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Mash 2",
+            "step_time": 60,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Mash Out",
+            "step_time": 0,
+            "temperature": 185
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Mash Out",
+            "step_time": 15,
+            "temperature": 185
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 60,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Cool to Whirlpoo...",
+            "step_time": 0,
+            "temperature": 175
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct2",
+            "name": "Whirlpool Step",
+            "step_time": 15,
+            "temperature": 175
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 73
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 73
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Saison_____________-.json
+++ b/recipes_snapshot/zseries/Saison_____________-.json
@@ -1,0 +1,64 @@
+{
+    "clean": false,
+    "id": 153834,
+    "name": "Saison             -",
+    "start_water": 13.74,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 40,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Adjunct2",
+            "name": "Boil Adjunct 2",
+            "step_time": 15,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct3",
+            "name": "Boil Adjunct 3",
+            "step_time": 5,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 72
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 72
+        }
+    ]
+}

--- a/recipes_snapshot/zseries/Weissbier__________-.json
+++ b/recipes_snapshot/zseries/Weissbier__________-.json
@@ -1,0 +1,50 @@
+{
+    "clean": false,
+    "id": 147355,
+    "name": "Weissbier          -",
+    "start_water": 12.83,
+    "steps": [
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Single S...",
+            "step_time": 0,
+            "temperature": 152
+        },
+        {
+            "drain_time": 8,
+            "location": "Mash",
+            "name": "Single Step Infu...",
+            "step_time": 90,
+            "temperature": 152
+        },
+        {
+            "drain_time": 0,
+            "location": "PassThru",
+            "name": "Heat to Boil",
+            "step_time": 0,
+            "temperature": 207
+        },
+        {
+            "drain_time": 5,
+            "location": "Adjunct1",
+            "name": "Boil Adjunct 1",
+            "step_time": 60,
+            "temperature": 207
+        },
+        {
+            "drain_time": 0,
+            "location": "Pause",
+            "name": "Connect Chiller",
+            "step_time": 0,
+            "temperature": 70
+        },
+        {
+            "drain_time": 10,
+            "location": "PassThru",
+            "name": "Chill",
+            "step_time": 10,
+            "temperature": 70
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ requests==2.31.0
 ruamel.yaml==0.18.6
 webargs==8.3.0
 Werkzeug==2.2.3
+beautifulsoup4==4.12.3

--- a/scripts/fetch_public_recipes.py
+++ b/scripts/fetch_public_recipes.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+# Default entry URL for PicoBrew community recipes
+DEFAULT_START_URL = "https://www.picobrew.com/publicrecipes/publicrecipes"
+
+
+def log(msg: str):
+    print(f"[fetch_public_recipes] {msg}", flush=True)
+
+
+def safe_filename(name: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]", "_", name)[:200]
+
+
+def is_same_domain(base: str, link: str) -> bool:
+    bu = urlparse(base)
+    lu = urlparse(link)
+    return (lu.netloc == "" or lu.netloc == bu.netloc)
+
+
+def extract_links(html: str, base_url: str):
+    soup = BeautifulSoup(html, "html.parser")
+    hrefs = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"].strip()
+        full = urljoin(base_url, href)
+        # Filter to same domain and paths that look like public recipe pages
+        if (is_same_domain(base_url, full)
+                and (
+                    "/publicrecipes/recipe" in full
+                    or "/publicrecipes/details" in full
+                    or ("/publicrecipes" in full and full.rstrip("/") != DEFAULT_START_URL.rstrip("/"))
+                )):
+            hrefs.append(full)
+    return list(dict.fromkeys(hrefs))  # dedupe, preserve order
+
+
+def fetch_all(start_url: str, out_dir: Path, delay: float = 0.5, timeout: int = 20):
+    session = requests.Session()
+    # Site currently presents an expired certificate; allow insecure with verify=False
+    verify = False
+
+    crawled = set()
+    to_visit = [start_url]
+    recipes = []
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    while to_visit:
+        url = to_visit.pop(0)
+        if url in crawled:
+            continue
+        crawled.add(url)
+
+        try:
+            log(f"GET {url}")
+            resp = session.get(url, timeout=timeout, verify=verify)
+            if resp.status_code != 200:
+                log(f"WARN: status {resp.status_code} for {url}")
+                continue
+            html = resp.text
+        except Exception as e:
+            log(f"ERROR: {e} for {url}")
+            continue
+
+        # Save page if it appears to be a recipe detail page (heuristic)
+        # Heuristics: contains keywords or specific structures; fall back to saving all under publicrecipes path
+        is_detail = any(s in url for s in ["/publicrecipes/recipe", "/publicrecipes/details"]) or ("/publicrecipes/" in url and url.rstrip("/") != DEFAULT_START_URL.rstrip("/"))
+        if is_detail:
+            # Derive filename from URL path
+            parsed = urlparse(url)
+            slug = safe_filename(parsed.path.strip("/").replace("/", "_"))
+            if not slug:
+                slug = f"recipe_{len(recipes)+1}"
+            html_path = out_dir / f"{slug}.html"
+            html_path.write_text(html, encoding="utf-8")
+            recipes.append({
+                "url": url,
+                "file": html_path.name,
+                "title": BeautifulSoup(html, "html.parser").title.string.strip() if BeautifulSoup(html, "html.parser").title else slug,
+            })
+
+        # Extract more links (pagination and details)
+        links = extract_links(html, url)
+        for link in links:
+            if link not in crawled and link not in to_visit:
+                to_visit.append(link)
+
+        time.sleep(delay)
+
+    # Write index
+    index = {
+        "start_url": start_url,
+        "count": len(recipes),
+        "recipes": recipes,
+    }
+    (out_dir / "index.json").write_text(json.dumps(index, indent=2), encoding="utf-8")
+    log(f"Saved {len(recipes)} pages to {out_dir}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch PicoBrew community public recipes")
+    parser.add_argument("--start-url", default=DEFAULT_START_URL, help="Starting URL for community recipes")
+    parser.add_argument("--out-dir", default=str(Path("app/recipes/public_html").resolve()), help="Output directory for saved HTML and index.json")
+    parser.add_argument("--delay", type=float, default=0.5, help="Delay between requests (seconds)")
+    parser.add_argument("--timeout", type=int, default=20, help="Request timeout (seconds)")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    fetch_all(args.start_url, out_dir, delay=args.delay, timeout=args.timeout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/fetch_zseries_all.py
+++ b/scripts/fetch_zseries_all.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import time
+from pathlib import Path
+import requests
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from app import create_app
+from app.main.config import MachineType
+from app.main.recipe_import import ZSeriesDataSyncURI, ZSeriesMetaSyncURI, Z_AUTH_TOKEN
+from app.main.recipe_parser import ZSeriesRecipeImport
+from flask import current_app
+
+
+def fetch_list(session: requests.Session, token: str, kind: int, max_count: int, offset: int):
+    uri = ZSeriesMetaSyncURI(token)
+    r = session.post(uri, verify=False, json={"Kind": kind, "MaxCount": max_count, "Offset": offset})
+    if r.status_code != 200:
+        raise RuntimeError(f"Failed list at offset {offset}: {r.status_code} {r.text}")
+    return r.json()
+
+
+def fetch_detail(session: requests.Session, token: str, rid: str):
+    uri = ZSeriesDataSyncURI(token, rid)
+    r = session.get(uri, verify=False)
+    if r.status_code != 200:
+        raise RuntimeError(f"Failed detail {rid}: {r.status_code} {r.text}")
+    return r.json()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch ALL Z-series recipes and import to local library")
+    parser.add_argument("--token", required=True, help="Z-series token (Product ID)")
+    parser.add_argument("--max", type=int, default=200, help="Page size per request (default 200)")
+    parser.add_argument("--sleep", type=float, default=0.1, help="Delay between requests")
+    args = parser.parse_args()
+
+    app = create_app(debug=False)
+    with app.app_context():
+        session = requests.Session()
+        session.headers = requests.structures.CaseInsensitiveDict({
+            "host": "www.picobrew.com",
+            "Authorization": Z_AUTH_TOKEN,
+            "Content-Type": "application/json",
+        })
+
+        total = 0
+        offset = 0
+        imported = 0
+        seen_ids = set()
+        while True:
+            try:
+                listing = fetch_list(session, args.token, kind=1, max_count=args.max, offset=offset)
+            except Exception as e:
+                print(f"[zseries-all] list error at offset {offset}: {e}")
+                break
+            recipes = listing.get("Recipes") or []
+            if not recipes:
+                break
+            print(f"[zseries-all] batch offset={offset} count={len(recipes)}")
+            for rec in recipes:
+                rid = rec.get("ID")
+                if rid is None or rid in seen_ids:
+                    continue
+                seen_ids.add(rid)
+                try:
+                    session.headers = requests.structures.CaseInsensitiveDict({
+                        "host": "www.picobrew.com",
+                        "Authorization": Z_AUTH_TOKEN,
+                    })
+                    detail = fetch_detail(session, args.token, str(rid))
+                    ZSeriesRecipeImport(detail)
+                    imported += 1
+                except Exception as e:
+                    print(f"[zseries-all] detail error for {rid}: {e}")
+                time.sleep(args.sleep)
+            total += len(recipes)
+            offset += len(recipes)
+            time.sleep(args.sleep)
+        print(f"[zseries-all] done: listed={total} imported={imported}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/fetch_zseries_catalog.py
+++ b/scripts/fetch_zseries_catalog.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from app import create_app
+from app.main.recipe_import import import_recipes_z
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch Z-series recipe catalog using device token")
+    parser.add_argument("--token", required=True, help="Z-series token (Product ID)")
+    args = parser.parse_args()
+
+    app = create_app(debug=False)
+    with app.app_context():
+        import_recipes_z(args.token)
+        print("Z-series catalog import completed.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/scripts/import_pico_by_rfid.py
+++ b/scripts/import_pico_by_rfid.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from app import create_app
+from app.main.config import MachineType
+from app.main.recipe_import import import_recipes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import Pico (Pico S/C/Pro) recipe by RFID for a device UID")
+    parser.add_argument("--uid", required=True, help="Pico device UID (32-char)")
+    parser.add_argument("--rfid", required=True, help="PicoPak RFID (14-char) to import")
+    args = parser.parse_args()
+
+    app = create_app(debug=False)
+    with app.app_context():
+        import_recipes(args.uid, None, args.rfid, MachineType.PICOBREW)
+        print("Pico import completed.")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/import_zymatic_user.py
+++ b/scripts/import_zymatic_user.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from app import create_app
+from app.main.config import MachineType
+from app.main.recipe_import import import_recipes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import Zymatic recipes for a user via GUID and Product ID")
+    parser.add_argument("--guid", required=True, help="User profile GUID (accountId)")
+    parser.add_argument("--product-id", required=True, help="Zymatic Product ID")
+    args = parser.parse_args()
+
+    app = create_app(debug=False)
+    with app.app_context():
+        import_recipes(args.product_id, args.guid, None, MachineType.ZYMATIC)
+        print("Zymatic import completed.")
+
+if __name__ == "__main__":
+    main()
+

--- a/setup.sh
+++ b/setup.sh
@@ -395,6 +395,19 @@ main() {
     # Start the server in background, verify health, run smoke, and open browser
     start_server_bg_and_verify "$PORT" "$HOST"
 
+    # Offer to import bundled snapshot recipes if present
+    if [[ -d "recipes_snapshot/zseries" ]]; then
+        echo -n "Import bundled Z-series recipes snapshot into server library? [y/N]: "
+        read -r reply
+        if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+            mkdir -p app/recipes/zseries
+            cp -n recipes_snapshot/zseries/*.json app/recipes/zseries/ || true
+            print_success "Imported Z-series snapshot recipes."
+        else
+            print_status "Skipping bundled Z-series import."
+        fi
+    fi
+
     # Prompt to import PicoBrew community recipes (HTML snapshots)
     if [[ "$IMPORT_COMMUNITY" == "true" ]]; then
         echo -n "Do you want to fetch the PicoBrew community recipe library locally? [y/N]: "

--- a/setup.sh
+++ b/setup.sh
@@ -432,6 +432,52 @@ main() {
         else
             print_status "PicoBrew vendor site not reachable, skipping user Z-series import."
         fi
+
+        # Offer to import user's Zymatic recipes (requires GUID and Product ID)
+        if curl -sS -k --max-time 5 http://137.117.17.70/ [0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m [0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m [0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m[0m; then
+            echo -n "Import YOUR Zymatic recipes? (requires GUID and Product ID) [y/N]: "
+            read -r reply
+            if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+                echo -n "Enter your Zymatic GUID: "
+                read -r ZY_GUID
+                echo -n "Enter your Zymatic Product ID: "
+                read -r ZY_PID
+                if [[ -n "$ZY_GUID" ]] && [[ -n "$ZY_PID" ]]; then
+                    create_and_use_venv
+                    if python scripts/import_zymatic_user.py --guid "$ZY_GUID" --product-id "$ZY_PID"; then
+                        print_success "Imported your Zymatic recipes into app/recipes/zymatic/"
+                    else
+                        print_warning "Failed to import Zymatic recipes. You can retry later via: python scripts/import_zymatic_user.py --guid GUID --product-id PID"
+                    fi
+                else
+                    print_warning "GUID or Product ID missing, skipping Zymatic import."
+                fi
+            else
+                print_status "Skipping user Zymatic recipe import."
+            fi
+        fi
+
+        # Offer to import a Pico recipe by RFID (requires UID and RFID)
+        echo -n "Import a Pico (Pico S/C/Pro) recipe by RFID now? [y/N]: "
+        read -r reply
+        if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+            echo -n "Enter your Pico device UID (32 chars): "
+            read -r PICO_UID
+            echo -n "Enter PicoPak RFID (14 chars): "
+            read -r PICO_RFID
+            if [[ -n "$PICO_UID" ]] && [[ -n "$PICO_RFID" ]]; then
+                create_and_use_venv
+                if python scripts/import_pico_by_rfid.py --uid "$PICO_UID" --rfid "$PICO_RFID"; then
+                    print_success "Imported Pico recipe into app/recipes/pico/"
+                else
+                    print_warning "Failed to import Pico recipe."
+                fi
+            else
+                print_warning "UID or RFID missing, skipping Pico import."
+            fi
+        else
+            print_status "Skipping Pico recipe import."
+        fi
     fi
 
     # Prompt to import PicoBrew community recipes (HTML snapshots)

--- a/setup.sh
+++ b/setup.sh
@@ -237,6 +237,7 @@ show_usage() {
     echo "  -t, --test          Run tests after setup"
     echo "  -s, --setup-only    Only setup dependencies, don't start server"
     echo "  -v, --verbose       Verbose output"
+    echo "  --import-community  Prompt to import PicoBrew community recipes (HTML snapshots)"
     echo ""
     echo "Examples:"
     echo "  $0                    # Auto-setup and start server"
@@ -282,6 +283,7 @@ main() {
     RUN_TESTS=false
     SETUP_ONLY=false
     VERBOSE=false
+    IMPORT_COMMUNITY=false
     
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -307,6 +309,10 @@ main() {
                 ;;
             -v|--verbose)
                 VERBOSE=true
+                shift
+                ;;
+            --import-community)
+                IMPORT_COMMUNITY=true
                 shift
                 ;;
             *)
@@ -388,6 +394,23 @@ main() {
 
     # Start the server in background, verify health, run smoke, and open browser
     start_server_bg_and_verify "$PORT" "$HOST"
+
+    # Prompt to import PicoBrew community recipes (HTML snapshots)
+    if [[ "$IMPORT_COMMUNITY" == "true" ]]; then
+        echo -n "Do you want to fetch the PicoBrew community recipe library locally? [y/N]: "
+        read -r reply
+        if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+            print_status "Fetching PicoBrew public recipes (this may take a while)..."
+            create_and_use_venv
+            if python scripts/fetch_public_recipes.py; then
+                print_success "Community recipes snapshot saved to app/recipes/public_html"
+            else
+                print_warning "Failed to fetch community recipes. You can retry later via: python scripts/fetch_public_recipes.py"
+            fi
+        else
+            print_status "Skipping community recipe import."
+        fi
+    fi
 
     # Optional smoke test if script exists
     if [[ -f "scripts/smoke.sh" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -408,6 +408,32 @@ main() {
         fi
     fi
 
+    # Offer to import user's Z-series recipes from PicoBrew (if site reachable)
+    if command_exists curl; then
+        if curl -sS -k --max-time 5 https://137.117.17.70/ >/dev/null 2>&1; then
+            echo -n "Import YOUR Z-series recipes from PicoBrew now? (requires Product ID token) [y/N]: "
+            read -r reply
+            if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+                echo -n "Enter your Z-series Product ID token: "
+                read -r Z_TOKEN
+                if [[ -n "$Z_TOKEN" ]]; then
+                    create_and_use_venv
+                    if python scripts/fetch_zseries_all.py --token "$Z_TOKEN"; then
+                        print_success "Imported your Z-series recipes into app/recipes/zseries/"
+                    else
+                        print_warning "Failed to import Z-series recipes. You can retry later via: python scripts/fetch_zseries_all.py --token YOUR_TOKEN"
+                    fi
+                else
+                    print_warning "No token provided, skipping user recipe import."
+                fi
+            else
+                print_status "Skipping user Z-series recipe import."
+            fi
+        else
+            print_status "PicoBrew vendor site not reachable, skipping user Z-series import."
+        fi
+    fi
+
     # Prompt to import PicoBrew community recipes (HTML snapshots)
     if [[ "$IMPORT_COMMUNITY" == "true" ]]; then
         echo -n "Do you want to fetch the PicoBrew community recipe library locally? [y/N]: "


### PR DESCRIPTION

Update: Removed the Community/Snapshots navbar link since the data is user-specific and not a global community catalog. The setup now offers optional per-user imports (Z-series/Zymatic/Pico) and a one-time Z-series snapshot can still be imported during setup if present.